### PR TITLE
Fix almost all compile warnings

### DIFF
--- a/benchmarks/bruck_allgather.cpp
+++ b/benchmarks/bruck_allgather.cpp
@@ -57,7 +57,7 @@ int main(int argc, char* argv[])
             if (fabs(std_allgather[j] - bruck_allgather[j]) > 1e-10)
             {
                 fprintf(stderr, 
-                        "Rank %d, idx %d, std %d, bruck %d\n", 
+                        "Rank %d, idx %d, std %f, bruck %f\n", 
                          rank, j, std_allgather[j], bruck_allgather[j]);
                 MPI_Abort(MPI_COMM_WORLD, 1);
                 return 1;
@@ -78,7 +78,7 @@ int main(int argc, char* argv[])
             if (fabs(std_allgather[j] - bruck_allgather[j]) > 1e-10)
             {
                 fprintf(stderr,
-                        "Rank %d, idx %d, std %d, bruck %d\n",
+                        "Rank %d, idx %d, std %f, bruck %f\n",
                          rank, j, std_allgather[j], bruck_allgather[j]);
                 MPI_Abort(MPI_COMM_WORLD, 1);
                 return 1;
@@ -99,7 +99,7 @@ int main(int argc, char* argv[])
             if (fabs(std_allgather[j] - bruck_allgather[j]) > 1e-10)
             {
                 fprintf(stderr,
-                        "Rank %d, idx %d, std %d, bruck %d\n",
+                        "Rank %d, idx %d, std %f, bruck %f\n",
                          rank, j, std_allgather[j], bruck_allgather[j]);
                 MPI_Abort(MPI_COMM_WORLD, 1);
                 return 1;
@@ -119,7 +119,7 @@ int main(int argc, char* argv[])
             if (fabs(std_allgather[j] - bruck_allgather[j]) > 1e-10)
             {
                 fprintf(stderr,
-                        "Rank %d, idx %d, std %d, bruck %d\n",
+                        "Rank %d, idx %d, std %f, bruck %f\n",
                          rank, j, std_allgather[j], bruck_allgather[j]);
                 MPI_Abort(MPI_COMM_WORLD, 1);
                 return 1;

--- a/benchmarks/p2p_alltoall.cpp
+++ b/benchmarks/p2p_alltoall.cpp
@@ -56,7 +56,7 @@ int main(int argc, char* argv[])
             if (fabs(std_alltoall[j] - loc_alltoall[j]) > 1e-10)
             {
                 fprintf(stderr, 
-                        "Rank %d, idx %d, std %d, loc %d\n", 
+                        "Rank %d, idx %d, std %f, loc %f\n", 
                          rank, j, std_alltoall[j], loc_alltoall[j]);
                 MPI_Abort(MPI_COMM_WORLD, 1);
                 return 1;

--- a/benchmarks/p2p_alltoallv.cpp
+++ b/benchmarks/p2p_alltoallv.cpp
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
             if (fabs(std_alltoallv[j] - loc_alltoallv[j]) > 1e-10)
             {
                 fprintf(stderr, 
-                        "Rank %d, idx %d, std %d, loc %d\n", 
+                        "Rank %d, idx %d, std %f, loc %f\n", 
                          rank, j, std_alltoallv[j], loc_alltoallv[j]);
                 MPI_Abort(MPI_COMM_WORLD, 1);
                 return 1;

--- a/src/collective/allgather.c
+++ b/src/collective/allgather.c
@@ -271,8 +271,8 @@ int allgather_loc_bruck(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
     MPI_Type_size(recvtype, &recv_size);
 
     int local_rank, PPN;
-    MPI_Comm_rank(comm->local_comm, &local_rank);
-    MPI_Comm_size(comm->local_comm, &PPN);
+    MPI_Comm_rank(local_comm, &local_rank);
+    MPI_Comm_size(local_comm, &PPN);
 
     int local_node = rank / PPN;
     int num_nodes = num_procs / PPN;
@@ -280,7 +280,7 @@ int allgather_loc_bruck(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
     int tag = 102943;
 
     // Perform Local Allgather
-    allgather_bruck(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm->local_comm);
+    allgather_bruck(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, local_comm);
 
     // Perform allgather with PPN nodes at once
     // First send to node - (1 to PPN) nodes and recv from node + (1 to PPN) nodes
@@ -313,7 +313,7 @@ int allgather_loc_bruck(const void *sendbuf, int sendcount, MPI_Datatype sendtyp
         }
 
 
-        allgather_bruck(&(recv_buffer[recv_pos*recv_size]), size, recvtype, recvbuf, size, recvtype, comm->local_comm);
+        allgather_bruck(&(recv_buffer[recv_pos*recv_size]), size, recvtype, recvbuf, size, recvtype, local_comm);
 
         stride *= PPN;
     }
@@ -485,9 +485,9 @@ int allgather_hier_bruck(const void *sendbuf, int sendcount, MPI_Datatype sendty
     bcast(recvbuf, recvcount*num_procs, recvtype, 0, comm->local_comm);
 
     free(tmpbuf);
+
+    return 0;
 }
-
-
 
 
 int allgather_mult_hier_bruck(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
@@ -528,8 +528,6 @@ int allgather_mult_hier_bruck(const void *sendbuf, int sendcount, MPI_Datatype s
     }
 
     free(tmpbuf);
+
+    return 0;
 }
-
-
-
-

--- a/src/collective/alltoall.c
+++ b/src/collective/alltoall.c
@@ -93,6 +93,7 @@ int alltoall_pairwise(const void* sendbuf,
                 recvbuf + recv_pos, recvcount, recvtype, recv_proc, tag,
                 comm, &status);
     }
+    return 0;
 }
 
 int alltoall_bruck(const void* sendbuf,
@@ -212,8 +213,8 @@ int alltoall_pairwise_loc(const void* sendbuf,
     num_nodes = mpi_comm->num_nodes;
     rank_node = mpi_comm->rank_node;
 
-    const char* send_buffer = (char*) sendbuf;
-    char* recv_buffer = (char*) recvbuf;
+    // const char* send_buffer = (char*) sendbuf;
+    // char* recv_buffer = (char*) recvbuf;
     int sbytes, rbytes;
     MPI_Type_size(sendtype, &sbytes);
     MPI_Type_size(recvtype, &rbytes);

--- a/src/collective/alltoallv.c
+++ b/src/collective/alltoallv.c
@@ -133,7 +133,6 @@ int alltoallv_nonblocking(const void* sendbuf,
     int tag = 103044;
     int send_proc, recv_proc;
     int send_pos, recv_pos;
-    MPI_Status status;
 
     int send_size, recv_size;
     MPI_Type_size(sendtype, &send_size);
@@ -194,7 +193,6 @@ int alltoallv_pairwise_nonblocking(const void* sendbuf,
     int ctr;
     int send_proc, recv_proc;
     int send_pos, recv_pos;
-    MPI_Status status;
 
     int send_size, recv_size;
     MPI_Type_size(sendtype, &send_size);
@@ -273,8 +271,8 @@ int alltoallv_pairwise_loc(const void* sendbuf,
     num_nodes = mpi_comm->num_nodes;
     rank_node = mpi_comm->rank_node;
 
-    const char* send_buffer = (char*) sendbuf;
-    char* recv_buffer = (char*) recvbuf;
+    // const char* send_buffer = (char*) sendbuf;
+    // char* recv_buffer = (char*) recvbuf;
     int sbytes, rbytes;
     MPI_Type_size(sendtype, &sbytes);
     MPI_Type_size(recvtype, &rbytes);

--- a/src/collective/bcast.c
+++ b/src/collective/bcast.c
@@ -32,4 +32,5 @@ int bcast(void* buffer,
 
         stride /= 2;
     }
+    return 0;
 }

--- a/src/collective/gather.c
+++ b/src/collective/gather.c
@@ -44,5 +44,7 @@ int gather(const void* sendbuf,
 
         stride *= 2;
     }
+
+    return 0;
 }
 

--- a/src/neighborhood/neighbor.c
+++ b/src/neighborhood/neighbor.c
@@ -63,7 +63,8 @@ int init_communication(const void* sendbuffer,
         int* n_request_ptr,
         MPI_Request** request_ptr)
 {
-    int ierr, start, size;
+    int ierr = MPI_SUCCESS;
+    int start, size;
     int send_size, recv_size;
 
     char* send_buffer = (char*) sendbuffer;
@@ -126,10 +127,7 @@ int init_communicationw(const void* sendbuffer,
         int* n_request_ptr,
         MPI_Request** request_ptr)
 {
-    int ierr;
-
-    char* send_buffer = (char*) sendbuffer;
-    char* recv_buffer = (char*) recvbuffer;
+    int ierr = MPI_SUCCESS;
 
     MPI_Request* requests;
     *n_request_ptr = n_recvs+n_sends;
@@ -419,8 +417,6 @@ int MPIX_Neighbor_alltoallw_init(
 
     const char* send_buffer = (const char*)(sendbuffer);
     char* recv_buffer = (char*)(recvbuffer);
-    const int* send_buffer_int = (const int*)(sendbuffer);
-    int* recv_buffer_int = (int*)(recvbuffer);
 
     for (int i = 0; i < outdegree; i++)
     {
@@ -468,8 +464,6 @@ int MPIX_Neighbor_locality_alltoallv_init(
         MPI_Info info,
         MPIX_Request** request_ptr)
 {
-
-    int tag = 304591;
     int indegree, outdegree, weighted;
     MPI_Dist_graph_neighbors_count(
             comm->neighbor_comm, 
@@ -607,7 +601,6 @@ int MPIX_Neighbor_part_locality_alltoallv_init(
     int rank; 
     MPI_Comm_rank(comm->global_comm, &rank);
 
-    int tag = 304591;
     int indegree, outdegree, weighted;
     MPI_Dist_graph_neighbors_count(
             comm->neighbor_comm, 

--- a/src/persistent/persistent.c
+++ b/src/persistent/persistent.c
@@ -10,7 +10,8 @@ int MPIX_Start(MPIX_Request* request)
     if (request == NULL)
         return 0;
 
-    int ierr, idx;
+    int ierr = MPI_SUCCESS;
+    int idx;
 
     char* send_buffer = NULL;
     int recv_size = 0;
@@ -75,7 +76,8 @@ int MPIX_Wait(MPIX_Request* request, MPI_Status* status)
     if (request == NULL)
         return 0;
 
-    int ierr, idx;
+    int ierr = MPI_SUCCESS;
+    int idx;
 
     char* recv_buffer = NULL;
     int recv_size = 0;


### PR DESCRIPTION
This PR would fix most of the compile warnings. The only one it does not fix is related to the one from the call to `MPI_Dist_graph_create_adjacent`.

Exact changes:
- In the 3 benchmarks: changed `%d` to `%f` for things that were using floats
- `allgather.c` : converted usage of `comm->local-comm` to use the previously unused variable `local_comm` (which is set to `comm->local_comm`) ; added `return 0` to some functions
- `allltoall.c`: added `return 0` to a function ; commented out unused variables
- `alltoallv.c`: removed unused `MPI_Status` variables ; commented out unused buffer variables
- `bcast.c` and `gather.c`: added `return 0` to the functions
- `neighbor.c`: gave the `ierr` variables an initial value of "MPI_SUCCESS" ; removed unused tag variables ; removed unused buffer variables
- `persistent.c`: gave the `ierr` variables an initial value of "MPI_SUCCESS" 