### PR TITLE
Propagate MPI errors from underlying operations

### DIFF
--- a/src/collective/alltoall.c
+++ b/src/collective/alltoall.c
@@ -2,6 +2,7 @@
 #include <string.h>
 #include <math.h>
 #include "utils.h"
+#include "error.h"
 
 // TODO : Add Locality-Aware Bruck Alltoall Algorithm!
 // TODO : Change to PMPI_Alltoall and test with profiling library!
@@ -64,8 +65,8 @@ int alltoall_pairwise(const void* sendbuf,
         MPI_Comm comm)
 {
     int rank, num_procs;
-    MPI_Comm_rank(comm, &rank);
-    MPI_Comm_size(comm, &num_procs);
+    MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Comm_rank(comm, &rank));
+    MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Comm_size(comm, &num_procs));
 
     int tag = 102944;
     int send_proc, recv_proc;
@@ -73,8 +74,8 @@ int alltoall_pairwise(const void* sendbuf,
     MPI_Status status;
 
     int send_size, recv_size;
-    MPI_Type_size(sendtype, &send_size);
-    MPI_Type_size(recvtype, &recv_size);
+    MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Type_size(sendtype, &send_size));
+    MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Type_size(recvtype, &recv_size));
 
     // Send to rank + i
     // Recv from rank - i
@@ -89,10 +90,12 @@ int alltoall_pairwise(const void* sendbuf,
         send_pos = send_proc * sendcount * send_size;
         recv_pos = recv_proc * recvcount * recv_size;
 
-        MPI_Sendrecv(sendbuf + send_pos, sendcount, sendtype, send_proc, tag,
+        MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Sendrecv(sendbuf + send_pos, sendcount, sendtype, send_proc, tag,
                 recvbuf + recv_pos, recvcount, recvtype, recv_proc, tag,
-                comm, &status);
+                comm, &status));
     }
+
+    return MPI_SUCCESS;
 }
 
 int alltoall_bruck(const void* sendbuf,

--- a/src/collective/bcast.c
+++ b/src/collective/bcast.c
@@ -1,5 +1,6 @@
 #include "bcast.h"
 #include <math.h>
+#include "error.h"
 
 // TODO : currently root is always 0
 int bcast(void* buffer,
@@ -9,8 +10,8 @@ int bcast(void* buffer,
         MPI_Comm comm)
 {
     int rank, num_procs;
-    MPI_Comm_rank(comm, &rank);
-    MPI_Comm_size(comm, &num_procs);
+    MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Comm_rank(comm, &rank));
+    MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Comm_size(comm, &num_procs));
 
     int num_steps = log2(num_procs);
     int tag = 204857;
@@ -22,14 +23,15 @@ int bcast(void* buffer,
         if (rank % (stride*2) == 0)
         {
             // Sending Proc
-            MPI_Send(buffer, count, datatype, rank + stride, tag, comm);
+            MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Send(buffer, count, datatype, rank + stride, tag, comm));
         }
         else if (rank % stride == 0)
         {
             // Recving Proc
-            MPI_Recv(buffer, count, datatype, rank - stride, tag, comm, &status);
+            MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Recv(buffer, count, datatype, rank - stride, tag, comm, &status));
         }
 
         stride /= 2;
     }
+    return MPI_SUCCESS;
 }

--- a/src/collective/gather.c
+++ b/src/collective/gather.c
@@ -1,6 +1,8 @@
 #include "gather.h"
 #include <string.h>
 #include <math.h>
+#include "error.h"
+
 
 // TODO : Currently root is always 0
 int gather(const void* sendbuf,
@@ -13,11 +15,11 @@ int gather(const void* sendbuf,
         MPI_Comm comm)
 {
     int rank, num_procs;
-    MPI_Comm_rank(comm, &rank);
-    MPI_Comm_size(comm, &num_procs);
+    MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Comm_rank(comm, &rank));
+    MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Comm_size(comm, &num_procs));
 
     int recv_size;
-    MPI_Type_size(recvtype, &recv_size);
+    MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Type_size(recvtype, &recv_size));
 
     int num_steps = log2(num_procs);   
     int tag = 204857;
@@ -32,17 +34,18 @@ int gather(const void* sendbuf,
         if (rank % (stride*2))
         {
             // Sending Proc
-            MPI_Send(recvbuf, recvcount*stride, recvtype, rank - stride, tag, comm);
+            MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Send(recvbuf, recvcount*stride, recvtype, rank - stride, tag, comm));
             break;
         }
         else
         {
             // Recving Proc
-            MPI_Recv(&(recv_buffer[recvcount*stride*recv_size]), recvcount*stride, recvtype, 
-                    rank + stride, tag, comm, &status); 
+            MPI_ADVANCE_SUCCESS_OR_RETURN(MPI_Recv(&(recv_buffer[recvcount*stride*recv_size]), recvcount*stride, recvtype,
+                    rank + stride, tag, comm, &status)); 
         }
 
         stride *= 2;
     }
+    return MPI_SUCCESS;
 }
 

--- a/src/error.h
+++ b/src/error.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <mpi.h>
+
+#define MPI_ADVANCE_SUCCESS_OR_RETURN(_code) \
+  {if (MPI_SUCCESS != _code) return _code; }


### PR DESCRIPTION
Typically people configure MPI to die on an error, but let's return some errors in case they don't.