### PR TITLE
Fixed some warnings and CMake GPU quirk

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,5 +1,17 @@
-## Grab all .cpp files in test directory
-file(GLOB CPP_SOURCES CONFIGURE_DEPENDS "*.cpp")
+## Make a list for all the benchmarks to compile
+set(CPP_SOURCES "")
+
+## Most benchmarks will go in just fine
+list(APPEND CPP_SOURCES "alltoall_crs.cpp")
+list(APPEND CPP_SOURCES "alltoallv_crs.cpp")
+list(APPEND CPP_SOURCES "microbenchmarks.cpp")
+list(APPEND CPP_SOURCES "p2p_alltoall.cpp")
+list(APPEND CPP_SOURCES "p2p_alltoallv.cpp")
+
+## But some need special requirements
+if(USE_GPU)
+    list(APPEND CPP_SOURCES "gpu_alltoall.cpp")
+endif()
 
 ## All should be compiled appropriately (cxx vs nvcc vs hipcc)
 set_source_files_properties(${CPP_SOURCES} PROPERTIES LANGUAGE ${locality_aware_LANG})

--- a/benchmarks/p2p_alltoall.cpp
+++ b/benchmarks/p2p_alltoall.cpp
@@ -56,7 +56,7 @@ int main(int argc, char* argv[])
             if (fabs(std_alltoall[j] - loc_alltoall[j]) > 1e-10)
             {
                 fprintf(stderr, 
-                        "Rank %d, idx %d, std %d, loc %d\n", 
+                        "Rank %d, idx %d, std %f, loc %f\n", 
                          rank, j, std_alltoall[j], loc_alltoall[j]);
                 MPI_Abort(MPI_COMM_WORLD, 1);
                 return 1;

--- a/benchmarks/p2p_alltoallv.cpp
+++ b/benchmarks/p2p_alltoallv.cpp
@@ -39,12 +39,12 @@ int main(int argc, char* argv[])
         int s = pow(2, i);
         if (rank == 0) printf("Testing Size %d\n", s);
 
-        for (int i = 0; i < num_procs; i++)
+        for (int j = 0; j < num_procs; j++)
         {
-            send_sizes[i] = s;
-            send_displs[i+1] = send_displs[i] + s;
-            recv_sizes[i] = s;
-            recv_displs[i+1] = recv_displs[i] + s;
+            send_sizes[j] = s;
+            send_displs[j+1] = send_displs[j] + s;
+            recv_sizes[j] = s;
+            recv_displs[j+1] = recv_displs[j] + s;
         }
 
         for (int j = 0; j < s*num_procs; j++)
@@ -75,7 +75,7 @@ int main(int argc, char* argv[])
             if (fabs(std_alltoallv[j] - loc_alltoallv[j]) > 1e-10)
             {
                 fprintf(stderr, 
-                        "Rank %d, idx %d, std %d, loc %d\n", 
+                        "Rank %d, idx %d, std %f, loc %f\n", 
                          rank, j, std_alltoallv[j], loc_alltoallv[j]);
                 MPI_Abort(MPI_COMM_WORLD, 1);
                 return 1;

--- a/src/collective/alltoall.c
+++ b/src/collective/alltoall.c
@@ -137,7 +137,6 @@ int nonblocking_helper(const void* sendbuf,
 
     int send_proc, recv_proc;
     int send_pos, recv_pos;
-    MPI_Status status;
 
     char* recv_buffer = (char*)recvbuf;
     char* send_buffer = (char*)sendbuf;
@@ -253,11 +252,6 @@ int alltoall_multileader(
         local_comm = comm->leader_comm;
         group_comm = comm->leader_group_comm;
     }
-
-
-    int send_proc, recv_proc;
-    int send_pos, recv_pos;
-    MPI_Status status;
 
     char* recv_buffer = (char*)recvbuf;
     char* send_buffer = (char*)sendbuf;
@@ -433,12 +427,7 @@ int alltoall_locality_aware_helper(
     int ppg;
     MPI_Comm_size(local_comm, &ppg);
 
-    int send_proc, recv_proc;
-    int send_pos, recv_pos;
-    MPI_Status status;
-
     char* recv_buffer = (char*)recvbuf;
-    char* send_buffer = (char*)sendbuf;
 
     int send_size, recv_size;
     MPI_Type_size(sendtype, &send_size);
@@ -645,10 +634,6 @@ int alltoall_multileader_locality(
     int procs_per_leader, leader_rank;
     MPI_Comm_rank(comm->leader_comm, &leader_rank);
     MPI_Comm_size(comm->leader_comm, &procs_per_leader);
-
-    int send_proc, recv_proc;
-    int send_pos, recv_pos;
-    MPI_Status status;
 
     char* recv_buffer = (char*)recvbuf;
     char* send_buffer = (char*)sendbuf;

--- a/src/collective/alltoallv.c
+++ b/src/collective/alltoallv.c
@@ -283,7 +283,6 @@ int alltoallv_batch_async(const void* sendbuf,
     int tag;
     MPIX_Comm_tag(comm, &tag);
 
-    int ctr;
     int send_proc, recv_proc;
     int send_pos, recv_pos;
 

--- a/src/neighborhood/alltoall_crs.cpp
+++ b/src/neighborhood/alltoall_crs.cpp
@@ -12,8 +12,6 @@ int alltoall_crs_rma(int send_nnz, int* dest, int sendcount,
     MPI_Comm_rank(comm->global_comm, &rank);
     MPI_Comm_size(comm->global_comm, &num_procs);
 
-    int ctr, flag;
-
     // Get bytes per datatype, total bytes to be recvd (size of win_array)
     char* send_buffer;
     if (send_nnz)
@@ -51,6 +49,7 @@ int alltoall_crs_rma(int send_nnz, int* dest, int sendcount,
 
     std::vector<int> src;
     std::vector<char> recv_buffer;
+    int flag;
     for (int i = 0; i < num_procs; i++)
     {
         flag = 0;
@@ -247,7 +246,7 @@ void local_redistribute(int node_recv_size, std::vector<char>& recv_buf, std::ve
     MPI_Comm_rank(comm->local_comm, &local_rank);
     MPI_Comm_size(comm->local_comm, &PPN);
 
-    int send_bytes, recv_bytes, int_bytes;
+    int recv_bytes, int_bytes;
     MPI_Type_size(recvtype, &recv_bytes);
     MPI_Type_size(MPI_INT, &int_bytes);
     recv_bytes *= recvcount;
@@ -393,7 +392,7 @@ int alltoall_crs_personalized_loc(int send_nnz, int* dest, int sendcount,
 
     MPI_Status recv_status;
     int proc, ctr, start, end;
-    int count, n_msgs, n_sends, n_recvs, idx, new_idx;
+    int count, n_msgs, n_sends;
     int tag;
     MPIX_Comm_tag(comm, &tag);
 
@@ -524,7 +523,7 @@ int alltoall_crs_nonblocking_loc(int send_nnz, int* dest, int sendcount,
     MPI_Status recv_status;
     MPI_Request bar_req;
     int proc, ctr, flag, ibar, start, end;
-    int count, n_msgs, n_sends, n_recvs, idx, new_idx;
+    int count, n_msgs, n_sends;
     int tag;
     MPIX_Comm_tag(comm, &tag);
 


### PR DESCRIPTION
A couple of quick fixes:
- Removed all variables that were unused according to "unused variable" warnings
- Adjusted CMake code for the benchmarks to explicitly list all files so that GPU-based ones won't be built when `USE_GPU=OFF`
- Adjusted some `printf`s in the benchmarks
- Fixed the "shadowed variable" warning (please double check)

I left the "unused parameter" warnings alone since we don't need to worry about them.