### PR TITLE
Update CMake location varaible to be more specific

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,9 +22,8 @@ set(MPICXX "mpicxx" CACHE STRING "MPICXX command")
 set(MPIRUN "mpirun" CACHE STRING "MPIRUN command")
 set(CUDA_ARCH "75" CACHE STRING "CUDA Architecture")
 
-include_directories("${CMAKE_SOURCE_DIR}")
-include_directories("${CMAKE_SOURCE_DIR}/src")
-
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}")
+include_directories("${CMAKE_CURRENT_SOURCE_DIR}/src")
 
 # Find MPI
 find_package(MPI REQUIRED)


### PR DESCRIPTION
In the main cmake file, the lines: 
```cmake
include_directories("${CMAKE_SOURCE_DIR}")
include_directories("${CMAKE_SOURCE_DIR}/src")
```
Work fine when you build just this repo. But if you add this project as a nested project, `CMAKE_SOURCE_DIR` points to that directory instead of the locality_aware specific ones. Swapping to `CMAKE_CURRENT_SOURCE_DIR` fixes this issue.