### PR TITLE
Bad memory free in MPIX_Topo_free when degrees are zero

### DIFF
--- a/src/neighborhood/dist_topo.c
+++ b/src/neighborhood/dist_topo.c
@@ -119,12 +119,19 @@ int MPIX_Topo_free(MPIX_Topo** mpix_topo_ptr)
 {
     MPIX_Topo* mpix_topo = *mpix_topo_ptr;
 
-    free(mpix_topo->sources);
-    if(mpix_topo->sourceweights != MPI_UNWEIGHTED)
-        free(mpix_topo->sourceweights);
-    free(mpix_topo->destinations);
-    if(mpix_topo->destweights != MPI_UNWEIGHTED)
-        free(mpix_topo->destweights);
+    if(mpix_topo->indegree)
+    {
+        free(mpix_topo->sources);
+        if(mpix_topo->sourceweights != MPI_UNWEIGHTED)
+            free(mpix_topo->sourceweights);
+    }
+
+    if(mpix_topo->outdegree)
+    {
+        free(mpix_topo->destinations);
+        if(mpix_topo->destweights != MPI_UNWEIGHTED)
+            free(mpix_topo->destweights);
+    }
     free(mpix_topo);
     return MPI_SUCCESS;
 }


### PR DESCRIPTION
Tweaked MPIX_Topo_free to not try and free arrays it didn't make when degrees are 0. This involved adding a check around frees for if the in/out degrees are not 0, just like when the object was created.

@JStewart28 