### PR TITLE
Fix so spack can find mpiadvance

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,12 +136,6 @@ install(EXPORT mpiadvanceTargets
         NAMESPACE mpiadvance::
         DESTINATION lib/cmake/mpiadvance)
 
-# Generate the Config and Version files
-write_basic_package_version_file(
-  "${CMAKE_CURRENT_BINARY_DIR}/mpiadvanceConfigVersion.cmake"
-  VERSION 1.0.0
-  COMPATIBILITY SameMajorVersion)
-
 configure_package_config_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mpiadvanceConfig.cmake"
   "${CMAKE_CURRENT_BINARY_DIR}/mpiadvanceConfig.cmake"
@@ -149,5 +143,4 @@ configure_package_config_file(
 
 install(FILES
   "${CMAKE_CURRENT_BINARY_DIR}/mpiadvanceConfig.cmake"
-  "${CMAKE_CURRENT_BINARY_DIR}/mpiadvanceConfigVersion.cmake"
   DESTINATION lib/cmake/mpiadvance)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -99,10 +99,11 @@ add_library(mpi_advance
 )
 target_link_libraries(mpi_advance PUBLIC ${EXTERNAL_LIBS})
 
-install(TARGETS mpi_advance 
+install(TARGETS mpi_advance
         ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
         LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-        RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+        RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin
+)
 
 install(FILES src/mpi_advance.h DESTINATION ${CMAKE_INSTALL_PREFIX}/include)
 install(FILES ${utils_HEADERS} DESTINATION ${CMAKE_INSTALL_PREFIX}/include/utils)
@@ -123,4 +124,30 @@ endif()
 
 add_subdirectory(benchmarks)
 
+include(CMakePackageConfigHelpers)
 
+# Install the actual target(s) and register them for export
+install(TARGETS mpi_advance
+        EXPORT mpiadvanceTargets
+        DESTINATION lib)
+
+# Export the targets into a CMake package
+install(EXPORT mpiadvanceTargets
+        NAMESPACE mpiadvance::
+        DESTINATION lib/cmake/mpiadvance)
+
+# Generate the Config and Version files
+write_basic_package_version_file(
+  "${CMAKE_CURRENT_BINARY_DIR}/mpiadvanceConfigVersion.cmake"
+  VERSION 1.0.0
+  COMPATIBILITY SameMajorVersion)
+
+configure_package_config_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/cmake/mpiadvanceConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/mpiadvanceConfig.cmake"
+  INSTALL_DESTINATION lib/cmake/mpiadvance)
+
+install(FILES
+  "${CMAKE_CURRENT_BINARY_DIR}/mpiadvanceConfig.cmake"
+  "${CMAKE_CURRENT_BINARY_DIR}/mpiadvanceConfigVersion.cmake"
+  DESTINATION lib/cmake/mpiadvance)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ endif()
 
 add_subdirectory(benchmarks)
 
+### Installation Requirements for Spack Package ###
 include(CMakePackageConfigHelpers)
 
 # Install the actual target(s) and register them for export
@@ -144,3 +145,5 @@ configure_package_config_file(
 install(FILES
   "${CMAKE_CURRENT_BINARY_DIR}/mpiadvanceConfig.cmake"
   DESTINATION lib/cmake/mpiadvance)
+############## End of Spack Section ################
+


### PR DESCRIPTION
Added lines at the end of CMakeLists.txt. The code works, but I am open to changes if there is a more elegant way to incorporate it into the existing CMake.