### PR TITLE
Minor tweak to CMake code when user doesn't specify a CMake build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ set(CMAKE_C_STANDARD 11)
 # Set default build type
 if(NOT CMAKE_BUILD_TYPE)
 	message(STATUS "No CMAKE_BUILD_TYPE specified, setting build type to RELEASE.")
-	set(CMAKE_BUILD_TYPE "RELEASE")
+	set(CMAKE_BUILD_TYPE RELEASE CACHE STRING "Build type for project." FORCE)
 endif()
 
 # Convert to lower case string to ignore case


### PR DESCRIPTION
When the build type is not specified, the local code does build in release mode as expected, but the way we did it did not propagate the build type into the exported cmake module file for some reason. This PR does a minor tweak to fix that.