### PR TITLE
Move add_test command inside ENABLE_UNIT_TESTS check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ endif()
 
 if (ENABLE_UNIT_TESTS)
     enable_testing()
-	set(TEST_PROCS "16" CACHE STRING "Number of processes to use when making ctests")
+	set(TEST_PROCS "4" CACHE STRING "Number of processes to use when making ctests")
 endif()
 
 # Flag == TRUE means TEST

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,13 +84,12 @@ function(make_executable filename flag)
 
 	if(${flag})
 		set(locality_test_name ${exec_name}_Test)
+		if(ENABLE_UNIT_TESTS)
+			add_test(NAME ${locality_test_name} COMMAND ${MPIRUN} -n ${TEST_PROCS} ./${exec_name} ${TEST_MATRIX_FILE})
+		endif()
 	else()
 		set(locality_test_name ${exec_name}_Benchmark)
 		install(TARGETS ${exec_name} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-	endif()
-
-	if(ENABLE_UNIT_TESTS)
-		add_test(NAME ${locality_test_name} COMMAND ${MPIRUN} -n ${TEST_PROCS} ./${exec_name} ${TEST_MATRIX_FILE})
 	endif()
 
 endfunction()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,11 +84,8 @@ function(make_executable filename flag)
 
 	if(${flag})
 		set(locality_test_name ${exec_name}_Test)
-		if(ENABLE_UNIT_TESTS)
-			add_test(NAME ${locality_test_name} COMMAND ${MPIRUN} -n ${TEST_PROCS} ./${exec_name} ${TEST_MATRIX_FILE})
-		endif()
+		add_test(NAME ${locality_test_name} COMMAND ${MPIRUN} -n ${TEST_PROCS} ./${exec_name} ${TEST_MATRIX_FILE})
 	else()
-		set(locality_test_name ${exec_name}_Benchmark)
 		install(TARGETS ${exec_name} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
 	endif()
 

--- a/library/CMakeLists.txt
+++ b/library/CMakeLists.txt
@@ -1,5 +1,8 @@
 target_include_directories(locality_aware PRIVATE 
 		$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 add_subdirectory(bindings) 
-add_subdirectory(source) 
-add_subdirectory(tests)
+add_subdirectory(source)
+
+if (ENABLE_UNIT_TESTS)
+	add_subdirectory(tests)
+endif()

--- a/library/source/neighborhood/locality/neighbor_locality.cpp
+++ b/library/source/neighborhood/locality/neighbor_locality.cpp
@@ -1,6 +1,7 @@
 #include "neighborhood/neighbor_locality.h"
 
 #include <algorithm>
+#include <cstring>
 
 #include "locality_aware.h"
 #include "communicator/MPIL_Comm.hpp"


### PR DESCRIPTION
When we run 'make test' I believe we only want to compile and run tests.  Benchmarks are expecting larger process counts and some of them don't run on my computer.

If we do want benchmarks to run at small scales during `make test`, I can instead edit benchmarks to do smaller runs by default.