### PR TITLE
Add a Caching mechanism for created toplogy communicators

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ cmake_policy(VERSION 3.21.1...3.27)
 project(locality_aware VERSION 2.0.0 LANGUAGES C CXX)
 
 # Set C,CXX standards
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_C_STANDARD 11)
 
 # Set default build type

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The locality_aware library is a straightforward CMake projects with modest depen
 ## Software Dependencies
 - CMake 3.21
 - C 11
-- C++ 11
+- C++ 20
 - MPI
 - HIP or CUDA for GPU-based optimizations, if enabled
 

--- a/benchmarks/allreduce.cpp
+++ b/benchmarks/allreduce.cpp
@@ -125,7 +125,7 @@ int main(int argc, char* argv[])
         {
             MPI_Barrier(MPI_COMM_WORLD);
             t0 = MPI_Wtime();
-            for (int i = 0; i < 10; i++)
+            for (int j = 0; j < 10; j++)
             {
                 PMPI_Allreduce(send_data.data(), pmpi_allreduce.data(),
                         s, MPI_DOUBLE, MPI_SUM, MPI_COMM_WORLD);
@@ -171,7 +171,7 @@ int main(int argc, char* argv[])
         {
             MPI_Barrier(MPI_COMM_WORLD);
             t0 = MPI_Wtime();
-            for (int i = 0; i < 10; i++)
+            for (int j = 0; j < 10; j++)
             {
                 MPIL_Allreduce(send_data.data(), pmpi_allreduce.data(),
                         s, MPI_DOUBLE, MPI_SUM, xcomm);
@@ -216,7 +216,7 @@ int main(int argc, char* argv[])
         {
             MPI_Barrier(MPI_COMM_WORLD);
             t0 = MPI_Wtime();
-            for (int i = 0; i < 10; i++)
+            for (int j = 0; j < 10; j++)
             {
                 MPIL_Allreduce(send_data.data(), pmpi_allreduce.data(),
                         s, MPI_DOUBLE, MPI_SUM, xcomm);
@@ -262,7 +262,7 @@ int main(int argc, char* argv[])
         {
             MPI_Barrier(MPI_COMM_WORLD);
             t0 = MPI_Wtime();
-            for (int i = 0; i < 10; i++)
+            for (int j = 0; j < 10; j++)
             {
                 MPIL_Allreduce(send_data.data(), pmpi_allreduce.data(),
                         s, MPI_DOUBLE, MPI_SUM, xcomm);

--- a/benchmarks/alltoall_crs.cpp
+++ b/benchmarks/alltoall_crs.cpp
@@ -63,11 +63,7 @@ int main(int argc, char* argv[])
 
     // Read suitesparse matrix
     ParMat<int> A;
-    int file_error = readParMatrix(filename, A);
-    if (file_error)
-    {
-        return 1;
-    }
+    readParMatrix(filename, A);
     // Form Communication Package (A.send_comm, A.recv_comm)
     form_comm(A);
 

--- a/benchmarks/alltoallv_crs.cpp
+++ b/benchmarks/alltoallv_crs.cpp
@@ -98,11 +98,7 @@ int main(int argc, char* argv[])
 
     // Read suitesparse matrix
     ParMat<int> A;
-    int file_error = readParMatrix(filename, A);
-    if (file_error)
-    {
-        return 1;
-    }
+    readParMatrix(filename, A);
     // Form Communication Package (A.send_comm, A.recv_comm)
     form_comm(A);
 

--- a/benchmarks/reorder_msgs.cpp
+++ b/benchmarks/reorder_msgs.cpp
@@ -70,8 +70,6 @@ void par_spmv(ParMat<int>& A,
             std::vector<MPI_Request>& recv_req,
             MPIL_Comm* xcomm)
 {
-    int idx;
-
     // Pack sendbuf
     for (int i = 0; i < A.send_comm.size_msgs; i++)
         sendbuf[i] = x[A.send_comm.idx[i]];

--- a/benchmarks/reorder_msgs.cpp
+++ b/benchmarks/reorder_msgs.cpp
@@ -283,11 +283,7 @@ int main(int argc, char* argv[])
 
     // Read suitesparse matrix
     ParMat<int> A;
-    int file_error = readParMatrix(filename, A);
-    if (file_error)
-    {
-        return 1;
-    }
+    readParMatrix(filename, A);
 
     // Form Communication Package (A.send_comm, A.recv_comm)
     form_comm(A);

--- a/library/bindings/Collective/MPIL_Allgather.cpp
+++ b/library/bindings/Collective/MPIL_Allgather.cpp
@@ -7,47 +7,49 @@
 int MPIL_Allgather(const void* sendbuf,
                    int sendcount,
                    MPI_Datatype sendtype,
-                   void* recvbuf, 
+                   void* recvbuf,
                    int recvcount,
                    MPI_Datatype recvtype,
                    MPIL_Comm* comm)
 {
-    if (sendcount == 0) 
+    if (sendcount == 0)
     {
         return MPI_SUCCESS;
     }
 
     allgather_ftn method;
-    bool gpu_aware = false;
+#if defined(GPU)
+    bool gpu_aware   = false;
     bool copy_to_cpu = false;
+#endif
 
     switch (mpil_allgather_implementation)
     {
-#if defined(GPU) 
+#if defined(GPU)
 #if defined(GPU_AWARE)
         case ALLGATHER_GPU_RING:
-            method = allgather_ring;
+            method    = allgather_ring;
             gpu_aware = true;
             break;
         case ALLGATHER_GPU_BRUCK:
-            method = allgather_bruck;
+            method    = allgather_bruck;
             gpu_aware = true;
             break;
         case ALLGATHER_GPU_PMPI:
-            method = allgather_pmpi;
+            method    = allgather_pmpi;
             gpu_aware = true;
             break;
 #endif
         case ALLGATHER_CTC_RING:
-            method = allgather_ring;
+            method      = allgather_ring;
             copy_to_cpu = true;
             break;
         case ALLGATHER_CTC_BRUCK:
-            method = allgather_bruck;
+            method      = allgather_bruck;
             copy_to_cpu = true;
             break;
         case ALLGATHER_CTC_PMPI:
-            method = allgather_pmpi;
+            method      = allgather_pmpi;
             copy_to_cpu = true;
             break;
 #endif
@@ -63,21 +65,20 @@ int MPIL_Allgather(const void* sendbuf,
         default:
             method = allgather_pmpi;
             break;
-    } 
+    }
 
 #if defined(GPU)
     if (gpu_aware)
     {
-        return gpu_aware_collective(method, sendbuf, sendcount, sendtype,
-                recvbuf, recvcount, recvtype, comm);
+        return gpu_aware_collective(
+            method, sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm);
     }
     else if (copy_to_cpu)
     {
-        return copy_to_cpu_allgather(method, sendbuf, sendcount, sendtype,
-                recvbuf, recvcount, recvtype, comm);
-    }           
+        return copy_to_cpu_allgather(
+            method, sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm);
+    }
 #endif
 
-    return method(sendbuf, sendcount, sendtype, recvbuf, recvcount, 
-            recvtype, comm);
+    return method(sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, comm);
 }

--- a/library/bindings/Collective/MPIL_Allreduce.cpp
+++ b/library/bindings/Collective/MPIL_Allreduce.cpp
@@ -5,7 +5,7 @@
 #endif
 
 int MPIL_Allreduce(const void* sendbuf,
-                   void* recvbuf, 
+                   void* recvbuf,
                    int count,
                    MPI_Datatype datatype,
                    MPI_Op op,
@@ -17,52 +17,54 @@ int MPIL_Allreduce(const void* sendbuf,
     }
 
     allreduce_ftn method;
-    bool gpu_aware = false;
+#if defined(GPU)
+    bool gpu_aware   = false;
     bool copy_to_cpu = false;
+#endif
 
     switch (mpil_allreduce_implementation)
     {
-#if defined(GPU) 
+#if defined(GPU)
 #if defined(GPU_AWARE)
         case ALLREDUCE_GPU_RECURSIVE_DOUBLING:
-            method = allreduce_recursive_doubling;
+            method    = allreduce_recursive_doubling;
             gpu_aware = true;
             break;
         case ALLREDUCE_GPU_DISSEMINATION_LOC:
-            method = allreduce_dissemination_loc;
+            method    = allreduce_dissemination_loc;
             gpu_aware = true;
             break;
         case ALLREDUCE_GPU_DISSEMINATION_ML:
-            method = allreduce_dissemination_ml;
+            method    = allreduce_dissemination_ml;
             gpu_aware = true;
             break;
         case ALLREDUCE_GPU_DISSEMINATION_RADIX:
-            method = allreduce_dissemination_radix;
+            method    = allreduce_dissemination_radix;
             gpu_aware = true;
             break;
         case ALLREDUCE_GPU_PMPI:
-            method = allreduce_pmpi;
+            method    = allreduce_pmpi;
             gpu_aware = true;
             break;
 #endif
         case ALLREDUCE_CTC_RECURSIVE_DOUBLING:
-            method = allreduce_recursive_doubling;
+            method      = allreduce_recursive_doubling;
             copy_to_cpu = true;
             break;
         case ALLREDUCE_CTC_DISSEMINATION_LOC:
-            method = allreduce_dissemination_loc;
+            method      = allreduce_dissemination_loc;
             copy_to_cpu = true;
             break;
         case ALLREDUCE_CTC_DISSEMINATION_ML:
-            method = allreduce_dissemination_ml;
+            method      = allreduce_dissemination_ml;
             copy_to_cpu = true;
             break;
         case ALLREDUCE_CTC_DISSEMINATION_RADIX:
-            method = allreduce_dissemination_radix;
+            method      = allreduce_dissemination_radix;
             copy_to_cpu = true;
             break;
         case ALLREDUCE_CTC_PMPI:
-            method = allreduce_pmpi;
+            method      = allreduce_pmpi;
             copy_to_cpu = true;
             break;
 #endif
@@ -84,18 +86,16 @@ int MPIL_Allreduce(const void* sendbuf,
         default:
             method = allreduce_pmpi;
             break;
-    } 
+    }
 
 #if defined(GPU)
     if (gpu_aware)
     {
-        return gpu_aware_collective(method, sendbuf, recvbuf,
-                count, datatype, op, comm);
+        return gpu_aware_collective(method, sendbuf, recvbuf, count, datatype, op, comm);
     }
     else if (copy_to_cpu)
     {
-        return copy_to_cpu_allreduce(method, sendbuf, recvbuf,
-                count, datatype, op, comm);
+        return copy_to_cpu_allreduce(method, sendbuf, recvbuf, count, datatype, op, comm);
     }
 #endif
 

--- a/library/bindings/Collective/MPIL_Alltoall.cpp
+++ b/library/bindings/Collective/MPIL_Alltoall.cpp
@@ -16,34 +16,36 @@ int MPIL_Alltoall(const void* sendbuf,
                   MPI_Datatype recvtype,
                   MPIL_Comm* mpi_comm)
 {
-    if (sendcount == 0) 
+    if (sendcount == 0)
     {
         return MPI_SUCCESS;
     }
 
     alltoall_ftn method;
-    bool gpu_aware = false;
+#if defined(GPU)
+    bool gpu_aware   = false;
     bool copy_to_cpu = false;
+#endif
 
     switch (mpil_alltoall_implementation)
     {
-#if defined(GPU) 
+#if defined(GPU)
 #if defined(GPU_AWARE)
         case ALLTOALL_GPU_PAIRWISE:
-            method = alltoall_pairwise;
+            method    = alltoall_pairwise;
             gpu_aware = true;
             break;
         case ALLTOALL_GPU_NONBLOCKING:
-            method = alltoall_nonblocking;
+            method    = alltoall_nonblocking;
             gpu_aware = true;
             break;
 #endif
         case ALLTOALL_CTC_PAIRWISE:
-            method = alltoall_pairwise;
+            method      = alltoall_pairwise;
             copy_to_cpu = true;
             break;
         case ALLTOALL_CTC_NONBLOCKING:
-            method = alltoall_nonblocking;
+            method      = alltoall_nonblocking;
             copy_to_cpu = true;
             break;
 #endif
@@ -94,13 +96,13 @@ int MPIL_Alltoall(const void* sendbuf,
 #if defined(GPU)
     if (gpu_aware)
     {
-        return gpu_aware_collective(method, sendbuf, sendcount,
-                    sendtype, recvbuf, recvcount, recvtype, mpi_comm);
+        return gpu_aware_collective(
+            method, sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, mpi_comm);
     }
     else if (copy_to_cpu)
     {
-        return copy_to_cpu_alltoall(method, sendbuf, sendcount,
-                    sendtype, recvbuf, recvcount, recvtype, mpi_comm);
+        return copy_to_cpu_alltoall(
+            method, sendbuf, sendcount, sendtype, recvbuf, recvcount, recvtype, mpi_comm);
     }
 #endif
 

--- a/library/bindings/Collective/MPIL_Alltoallv.cpp
+++ b/library/bindings/Collective/MPIL_Alltoallv.cpp
@@ -19,28 +19,30 @@ int MPIL_Alltoallv(const void* sendbuf,
                    MPIL_Comm* mpi_comm)
 {
     alltoallv_ftn method;
-    bool gpu_aware = false;
+#if defined(GPU)
+    bool gpu_aware   = false;
     bool copy_to_cpu = false;
+#endif
 
     switch (mpil_alltoallv_implementation)
     {
 #if defined(GPU)
 #if defined(GPU_AWARE)
         case ALLTOALLV_GPU_PAIRWISE:
-            method = alltoallv_pairwise;
+            method    = alltoallv_pairwise;
             gpu_aware = true;
             break;
         case ALLTOALLV_GPU_NONBLOCKING:
-            method = alltoallv_nonblocking;
+            method    = alltoallv_nonblocking;
             gpu_aware = true;
             break;
 #endif
         case ALLTOALLV_CTC_PAIRWISE:
-            method = alltoallv_pairwise;
+            method      = alltoallv_pairwise;
             copy_to_cpu = true;
             break;
         case ALLTOALLV_CTC_NONBLOCKING:
-            method = alltoallv_nonblocking;
+            method      = alltoallv_nonblocking;
             copy_to_cpu = true;
             break;
 #endif
@@ -67,15 +69,29 @@ int MPIL_Alltoallv(const void* sendbuf,
 #if defined(GPU)
     if (gpu_aware)
     {
-        return gpu_aware_collective(method, sendbuf, sendcounts,
-                sdispls, sendtype, recvbuf, recvcounts, rdispls,
-                recvtype, mpi_comm);
+        return gpu_aware_collective(method,
+                                    sendbuf,
+                                    sendcounts,
+                                    sdispls,
+                                    sendtype,
+                                    recvbuf,
+                                    recvcounts,
+                                    rdispls,
+                                    recvtype,
+                                    mpi_comm);
     }
     else if (copy_to_cpu)
     {
-        return copy_to_cpu_alltoallv(method, sendbuf, sendcounts,
-                sdispls, sendtype, recvbuf, recvcounts, rdispls,
-                recvtype, mpi_comm);
+        return copy_to_cpu_alltoallv(method,
+                                     sendbuf,
+                                     sendcounts,
+                                     sdispls,
+                                     sendtype,
+                                     recvbuf,
+                                     recvcounts,
+                                     rdispls,
+                                     recvtype,
+                                     mpi_comm);
     }
 #endif
 

--- a/library/bindings/MPIL_Comm/MPIL_Comm_free.cpp
+++ b/library/bindings/MPIL_Comm/MPIL_Comm_free.cpp
@@ -13,16 +13,24 @@ int MPIL_Comm_free(MPIL_Comm** xcomm_ptr)
         xcomm->requests = NULL;
     }
 
+    free(xcomm->statuses);
+    xcomm->statuses = NULL;
+
     if (xcomm->neighbor_comm != MPI_COMM_NULL)
     {
         MPI_Comm_free(&(xcomm->neighbor_comm));
         xcomm->neighbor_comm = MPI_COMM_NULL;
     }
 
+    xcomm->local_comm.~CachedComm();
+    xcomm->group_comm.~CachedComm();
     MPIL_Comm_topo_free(xcomm);
+
     MPIL_Comm_leader_free(xcomm);
     MPIL_Comm_win_free(xcomm);
     MPIL_Comm_device_free(xcomm);
+
+    free_rank_mapping(xcomm);
 
     free(xcomm);
 

--- a/library/bindings/MPIL_Comm/MPIL_Comm_topo_free.cpp
+++ b/library/bindings/MPIL_Comm/MPIL_Comm_topo_free.cpp
@@ -12,17 +12,6 @@ int MPIL_Comm_topo_free(MPIL_Comm* xcomm)
         return MPI_SUCCESS;
     }
 
-    if (xcomm->local_comm != MPI_COMM_NULL)
-    {
-        MPI_Comm_free(&(xcomm->local_comm));
-        xcomm->local_comm = MPI_COMM_NULL;
-    }
-    if (xcomm->group_comm != MPI_COMM_NULL)
-    {
-        MPI_Comm_free(&(xcomm->group_comm));
-        xcomm->group_comm = MPI_COMM_NULL;
-    }
-
     free(xcomm->global_rank_to_local);
     xcomm->global_rank_to_local = NULL;
 

--- a/library/bindings/MPIL_Setup/MPIL_Finalize.cpp
+++ b/library/bindings/MPIL_Setup/MPIL_Finalize.cpp
@@ -8,6 +8,10 @@ extern "C" {
 int MPIL_Finalize()
 {
     MPIL_Comm_free(&MPIL_COMM_WORLD);
+
+    Communicator::cached_local_comms.clear();
+    Communicator::cached_group_comms.clear();
+
     return MPI_SUCCESS;
 }
 

--- a/library/bindings/MPIL_Setup/MPIL_Finalize.cpp
+++ b/library/bindings/MPIL_Setup/MPIL_Finalize.cpp
@@ -9,8 +9,7 @@ int MPIL_Finalize()
 {
     MPIL_Comm_free(&MPIL_COMM_WORLD);
 
-    Communicator::cached_local_comms.clear();
-    Communicator::cached_group_comms.clear();
+    Communicator::clear_comm_caches();
 
     return MPI_SUCCESS;
 }

--- a/library/include/communicator/MPIL_Comm.hpp
+++ b/library/include/communicator/MPIL_Comm.hpp
@@ -21,9 +21,9 @@ typedef struct _MPIL_Comm
     MPI_Comm neighbor_comm;
 
     // For hierarchical collectives
-    /**@brief Communicator for communicating inside the node**/
+    /**@brief Reference-counted MPI_Comm for communicating inside the node**/
     Communicator::CachedComm local_comm;
-    /**@brief Communicator containing leader process on each node**/
+    /**@brief Reference-counted MPI_Comm containing leader process on each node**/
     Communicator::CachedComm group_comm;
 
     /**@brief Communicator containing a single leader and its subordinates**/
@@ -114,11 +114,17 @@ int initialize_comm_object(MPIL_Comm** xcomm, MPI_Comm global_comm);
  * and used as the color for the MPI_Comm_split. The calculation of the the "node" is
  * determined by the templated parameter. If the template is false, "rank/ppn_override" is
  * used; if the template is true "rank % ppn_override" is used.
+ * 
+ * If the pairing of the MPIL_Comm::global_comm and the provided ppn_override have been used before,
+ * this method will bypass the calls to create a new MPI Communicator and will instead pull out the 
+ * appropriate communicator from Communicator::cached_local_comms to fill MPIL_Comm::local_comm and
+ * Communicator::cached_group_comms to fill MPIL_Comm::group_comm.
  * @tparam NUMA Controls how the grouping is made in the case that a PPN override is used.
  * @param [in, out] xcomm The ::_MPIL_Comm to store the topology communicators into.
  * @param [in] ppn_override Optional integer to determine how many processes are node.
  * If set, overrides default creation of MPIL_Comm::local_comm.
  * @return MPI_SUCCESS
+ * @sa Communicator::CachedComm
  **/
 template <bool NUMA = false>
 int initialize_topo_communicator(MPIL_Comm* xcomm, int ppn_override = 0)
@@ -182,15 +188,19 @@ int initialize_topo_communicator(MPIL_Comm* xcomm, int ppn_override = 0)
  **/
 int initialize_rank_mapping(MPIL_Comm* xcomm);
 
+/** @brief Free the arrays associated with process mapping inside an :_MPIL_Comm object
+ * @details More specifically, this method will free MPIL_Comm::global_rank_to_local,
+ * MPIL_Comm::global_rank_to_node, and MPIL_Comm::ordered_global_ranks.
+ * @return MPI_SUCCESS
+ **/
 int free_rank_mapping(MPIL_Comm* xcomm);
 
 /** @brief Gets current tag from xcomm then increments MPIL_Comm::tag
-        @details
-          Invoked externally by MPIL_Comm_get_tag
-        @param [in, out] xcomm communicator to query and updated
-        @param [out] tag value of xcomm->tag before the operations
-        @return MPI_SUCCESS
-**/
+ * @details Invoked externally by MPIL_Comm_get_tag
+ * @param [in, out] xcomm communicator to query and updated
+ * @param [out] tag value of xcomm->tag before the operations
+ * @return MPI_SUCCESS
+ **/
 int get_tag(MPIL_Comm* xcomm, int* tag);
 
 #endif

--- a/library/include/communicator/MPIL_Comm.hpp
+++ b/library/include/communicator/MPIL_Comm.hpp
@@ -152,6 +152,7 @@ int initialize_topo_communicator(MPIL_Comm* xcomm, int ppn_override = 0)
     MPI_Group global_group;
     MPI_Comm_group(xcomm->global_comm, &global_group);
 
+    /* Lambda for searching for if a particular group/ppn combo has been used before. */
     auto search_function = [global_group,
                             ppn_override](const Communicator::MapPairType& mpt) {
         if (std::get<1>(mpt.first) != ppn_override)
@@ -161,6 +162,7 @@ int initialize_topo_communicator(MPIL_Comm* xcomm, int ppn_override = 0)
 
         int result;
         MPI_Group_compare(global_group, std::get<0>(mpt.first), &result);
+        /* Currently only care about MPI_IDENT */
         return (result == MPI_IDENT);
     };
 
@@ -169,38 +171,39 @@ int initialize_topo_communicator(MPIL_Comm* xcomm, int ppn_override = 0)
                                         search_function);
 
     if (Communicator::cached_local_comms.end() != local_comm_iter)
-    {
+    { /* Used cached entry, so we can free the MPI_Group */
         MPI_Group_free(&global_group);
         xcomm->local_comm = local_comm_iter->second;
     }
     else
     {
         if (ppn_override > 0)
-        {  // Split communicator on a custom number of PPN
+        { /* Split communicator on a custom number of PPN */
             int color = (NUMA) ? rank % ppn_override : rank / ppn_override;
             MPI_Comm_split(xcomm->global_comm, color, rank, xcomm->local_comm);
         }
         else
-        {  // Split global comm into local (per node) communicators
+        { /* Split global comm into local (per node) communicators */
             MPI_Comm_split_type(xcomm->global_comm,
                                 MPI_COMM_TYPE_SHARED,
                                 rank,
                                 MPI_INFO_NULL,
                                 xcomm->local_comm);
         }
+        /* Cache new local communicator into map for reuse */
         Communicator::cached_local_comms.push_back(
             {{global_group, ppn_override}, xcomm->local_comm});
     }
 
-    // Get the group again, since it was either freed above, or cached (which will be
-    // freed at end of program)
+    /* Get the group again, since it was either freed above, or cached (which will be
+     * freed at end of program) */
     MPI_Comm_group(xcomm->global_comm, &global_group);
     auto group_comm_iter = std ::find_if(Communicator::cached_group_comms.begin(),
                                          Communicator::cached_group_comms.end(),
                                          search_function);
 
     if (Communicator::cached_group_comms.end() != group_comm_iter)
-    {
+    { /* Used cached entry, so we can free the MPI_Group */
         MPI_Group_free(&global_group);
         xcomm->group_comm = group_comm_iter->second;
     }
@@ -208,8 +211,8 @@ int initialize_topo_communicator(MPIL_Comm* xcomm, int ppn_override = 0)
     {
         int local_rank;
         MPI_Comm_rank(xcomm->local_comm, &local_rank);
-        // Split global comm into group (per local rank) communicators
         MPI_Comm_split(xcomm->global_comm, local_rank, rank, xcomm->group_comm);
+        /* Cache new group (per local rank) communicator into map for reuse */
         Communicator::cached_group_comms.push_back(
             {{global_group, ppn_override}, xcomm->group_comm});
     }

--- a/library/include/communicator/MPIL_Comm.hpp
+++ b/library/include/communicator/MPIL_Comm.hpp
@@ -1,6 +1,8 @@
 #ifndef MPIL_COMM_H
 #define MPIL_COMM_H
 
+#include <algorithm>
+
 #include "global_comms.hpp"
 
 /** @brief Struct capable of maintaining multiple request and communicators for library
@@ -114,11 +116,25 @@ int initialize_comm_object(MPIL_Comm** xcomm, MPI_Comm global_comm);
  * and used as the color for the MPI_Comm_split. The calculation of the the "node" is
  * determined by the templated parameter. If the template is false, "rank/ppn_override" is
  * used; if the template is true "rank % ppn_override" is used.
- * 
- * If the pairing of the MPIL_Comm::global_comm and the provided ppn_override have been used before,
- * this method will bypass the calls to create a new MPI Communicator and will instead pull out the 
- * appropriate communicator from Communicator::cached_local_comms to fill MPIL_Comm::local_comm and
+ *
+ * If the pairing of the MPIL_Comm::global_comm and the provided ppn_override have been
+ * used before, this method will bypass the calls to create a new MPI Communicator and
+ * will instead pull out the appropriate communicator from
+ * Communicator::cached_local_comms to fill MPIL_Comm::local_comm and
  * Communicator::cached_group_comms to fill MPIL_Comm::group_comm.
+ *
+ * To determine if a global_comm has been used before, the MPI_Group of the MPI_Comm is
+ * used. MPI_Groups are used instead of MPI_Comm since 1) duping communicators is a
+ * collective operation and 2) users could free the MPI_Comm used inside the
+ * ::MPIL_Comm::global_comm, which would result in potential segfaults on future
+ * MPI_Comm_compare calls. Since MPI_Group creation is local, and we do not care about the
+ * "context" of an MPI_Comm, we can get, store, and compare groups instead. Currently, the
+ * comparison is done with the help of std::find_if, and only checks for MPI_IDENT that
+ * comes from MPI_Group_compare.
+ *
+ * This method will free any MPI_Group that does not end up cached; cached MPI_Group
+ * objects will be freed via Communicator::clear_comm_caches in MPIL_Finalize.
+ *
  * @tparam NUMA Controls how the grouping is made in the case that a PPN override is used.
  * @param [in, out] xcomm The ::_MPIL_Comm to store the topology communicators into.
  * @param [in] ppn_override Optional integer to determine how many processes are node.
@@ -132,10 +148,30 @@ int initialize_topo_communicator(MPIL_Comm* xcomm, int ppn_override = 0)
     int rank;
     MPI_Comm_rank(xcomm->global_comm, &rank);
 
-    if (Communicator::cached_local_comms.contains({xcomm->global_comm, ppn_override}))
+    // Get the group, since we will compare those
+    MPI_Group global_group;
+    MPI_Comm_group(xcomm->global_comm, &global_group);
+
+    auto search_function = [global_group,
+                            ppn_override](const Communicator::MapPairType& mpt) {
+        if (std::get<1>(mpt.first) != ppn_override)
+        {
+            return false;
+        }
+
+        int result;
+        MPI_Group_compare(global_group, std::get<0>(mpt.first), &result);
+        return (result == MPI_IDENT);
+    };
+
+    auto local_comm_iter = std::find_if(Communicator::cached_local_comms.begin(),
+                                        Communicator::cached_local_comms.end(),
+                                        search_function);
+
+    if (Communicator::cached_local_comms.end() != local_comm_iter)
     {
-        xcomm->local_comm =
-            Communicator::cached_local_comms.at({xcomm->global_comm, ppn_override});
+        MPI_Group_free(&global_group);
+        xcomm->local_comm = local_comm_iter->second;
     }
     else
     {
@@ -152,24 +188,30 @@ int initialize_topo_communicator(MPIL_Comm* xcomm, int ppn_override = 0)
                                 MPI_INFO_NULL,
                                 xcomm->local_comm);
         }
-        Communicator::cached_local_comms.insert(
-            {{xcomm->global_comm, ppn_override}, xcomm->local_comm});
+        Communicator::cached_local_comms.push_back(
+            {{global_group, ppn_override}, xcomm->local_comm});
     }
 
-    if (Communicator::cached_group_comms.contains({xcomm->global_comm, ppn_override}))
+    // Get the group again, since it was either freed above, or cached (which will be
+    // freed at end of program)
+    MPI_Comm_group(xcomm->global_comm, &global_group);
+    auto group_comm_iter = std ::find_if(Communicator::cached_group_comms.begin(),
+                                         Communicator::cached_group_comms.end(),
+                                         search_function);
+
+    if (Communicator::cached_group_comms.end() != group_comm_iter)
     {
-        xcomm->group_comm =
-            Communicator::cached_group_comms.at({xcomm->global_comm, ppn_override});
+        MPI_Group_free(&global_group);
+        xcomm->group_comm = group_comm_iter->second;
     }
     else
     {
         int local_rank;
         MPI_Comm_rank(xcomm->local_comm, &local_rank);
-
         // Split global comm into group (per local rank) communicators
         MPI_Comm_split(xcomm->global_comm, local_rank, rank, xcomm->group_comm);
-        Communicator::cached_group_comms.insert(
-            {{xcomm->global_comm, ppn_override}, xcomm->group_comm});
+        Communicator::cached_group_comms.push_back(
+            {{global_group, ppn_override}, xcomm->group_comm});
     }
 
     return MPI_SUCCESS;

--- a/library/include/communicator/MPIL_Comm.hpp
+++ b/library/include/communicator/MPIL_Comm.hpp
@@ -16,55 +16,54 @@
  **/
 typedef struct _MPIL_Comm
 {
-    /**@brief Global MPI comm for reference, usually MPI_COMM_WORLD**/
+    /** @brief Global MPI comm for reference, usually MPI_COMM_WORLD **/
     MPI_Comm global_comm;
 
-    /**@brief communicator containing neighbor processes**/
+    /** @brief communicator containing neighbor processes **/
     MPI_Comm neighbor_comm;
 
     // For hierarchical collectives
-    /**@brief Reference-counted MPI_Comm for communicating inside the node**/
+    /** @brief Reference-counted MPI_Comm for communicating inside the node **/
     Communicator::CachedComm local_comm;
-    /**@brief Reference-counted MPI_Comm containing leader process on each node**/
+    /** @brief Reference-counted MPI_Comm containing leader process on each node **/
     Communicator::CachedComm group_comm;
 
-    /**@brief Communicator containing a single leader and its subordinates**/
+    /** @brief Communicator containing a single leader and its subordinates **/
     MPI_Comm leader_comm;
-    /**@brief Communicator containing all leaders **/
+    /** @brief Communicator containing all leaders **/
     MPI_Comm leader_group_comm;
-    /**@brief Communicator containing all leaders on a single node**/
+    /** @brief Communicator containing all leaders on a single node **/
     MPI_Comm leader_local_comm;
 
-    /**@brief Number of nodes in comm**/
+    /** @brief Number of nodes in comm **/
     int num_nodes;
-    /**@brief Rank of process in comm**/
+    /** @brief Rank of process in comm **/
     int rank_node;
-    /**@brief Processes per node**/
+    /** @brief Processes per node **/
     int ppn;
 
-    /**@brief MPI_window if using sync**/
+    /** @brief MPI_window if using sync **/
     MPI_Win win;
-    /**@brief Buffer for MPI_window**/
+    /** @brief Buffer for MPI_window **/
     char* win_array;
-    /**@brief Size of win_array in bytes**/
+    /** @brief Size of win_array in bytes **/
     int win_bytes;
-    /**@brief Size of the datatype in win_array in bytes**/
+    /** @brief Size of the datatype in win_array in bytes **/
     int win_type_bytes;
 
-    /**@brief Internal array of requests made during a blocking collective**/
+    /** @brief Internal array of requests made during a blocking collective **/
     MPI_Request* requests;
-    /**@brief Status the requests in requests**/
+    /** @brief Status the requests in requests **/
     MPI_Status* statuses;
 
-    /**@brief Size of requests and statuses
-       @details
-                    requests and statuses should always be the same size.
-                    can be updated through MPIL_Comm_req_resize;
-    **/
+    /** @brief Size of requests and statuses
+     *  @details requests and statuses should always be the same size. can be updated
+     * through MPIL_Comm_req_resize;
+     **/
     int n_requests;
-    /** @brief Unique identifier for any requests using this comm (defaulting to 126)**/
+    /** @brief Unique identifier for any requests using this comm (defaulting to 126) **/
     int tag;
-    /** @brief Maximum size of tag allowed by the system.**/
+    /** @brief Maximum size of tag allowed by the system. **/
     int max_tag;
 
     /** @brief Maps rank in global_comm to rank in local_comm **/
@@ -80,23 +79,24 @@ typedef struct _MPIL_Comm
     /** @brief Rank running on the gpu**/
     int rank_gpu;
     /** @brief Pointer to gpuStream_t
-                @details
-                        Changed to void* to assist compiling.
-                        Actual type is gpuStream_t, changed to void* to assist compiling.
-        */
+     * @details Changed to void* to assist compiling. Actual type is gpuStream_t, changed
+     * to void* to assist compiling.
+     **/
     void* proc_stream;
 #endif
 } MPIL_Comm;
 
-/** @brief Returns the node that process proc is on(data->global_rank_to_node[proc]**/
+/** @brief Returns the node that process proc is on (data->global_rank_to_node[proc]) **/
 int get_node(const MPIL_Comm* data, const int proc);
 
 /** @brief Return the rank of proc in local communicator (using
- * MPIL_Comm::global_rank_to_local)**/
+ * MPIL_Comm::global_rank_to_local)
+ **/
 int get_local_proc(const MPIL_Comm* data, const int proc);
 
 /** @brief Given a node and a rank of a process, get its rank in the global
- * communicator**/
+ * communicator
+ **/
 int get_global_proc(const MPIL_Comm* data, const int node, const int local_proc);
 
 /** @brief Constructor for an ::_MPIL_Comm object.

--- a/library/include/communicator/MPIL_Comm.hpp
+++ b/library/include/communicator/MPIL_Comm.hpp
@@ -1,7 +1,7 @@
 #ifndef MPIL_COMM_H
 #define MPIL_COMM_H
 
-#include <mpi.h>
+#include "global_comms.hpp"
 
 /** @brief Struct capable of maintaining multiple request and communicators for library
  * operations.
@@ -22,9 +22,9 @@ typedef struct _MPIL_Comm
 
     // For hierarchical collectives
     /**@brief Communicator for communicating inside the node**/
-    MPI_Comm local_comm;
+    Communicator::CachedComm local_comm;
     /**@brief Communicator containing leader process on each node**/
-    MPI_Comm group_comm;
+    Communicator::CachedComm group_comm;
 
     /**@brief Communicator containing a single leader and its subordinates**/
     MPI_Comm leader_comm;
@@ -126,25 +126,45 @@ int initialize_topo_communicator(MPIL_Comm* xcomm, int ppn_override = 0)
     int rank;
     MPI_Comm_rank(xcomm->global_comm, &rank);
 
-    if (ppn_override > 0)
-    {  // Split communicator on a custom number of PPN
-        int color = (NUMA) ? rank % ppn_override : rank / ppn_override;
-        MPI_Comm_split(xcomm->global_comm, color, rank, &(xcomm->local_comm));
+    if (Communicator::cached_local_comms.contains({xcomm->global_comm, ppn_override}))
+    {
+        xcomm->local_comm =
+            Communicator::cached_local_comms.at({xcomm->global_comm, ppn_override});
     }
     else
-    {  // Split global comm into local (per node) communicators
-        MPI_Comm_split_type(xcomm->global_comm,
-                            MPI_COMM_TYPE_SHARED,
-                            rank,
-                            MPI_INFO_NULL,
-                            &(xcomm->local_comm));
+    {
+        if (ppn_override > 0)
+        {  // Split communicator on a custom number of PPN
+            int color = (NUMA) ? rank % ppn_override : rank / ppn_override;
+            MPI_Comm_split(xcomm->global_comm, color, rank, xcomm->local_comm);
+        }
+        else
+        {  // Split global comm into local (per node) communicators
+            MPI_Comm_split_type(xcomm->global_comm,
+                                MPI_COMM_TYPE_SHARED,
+                                rank,
+                                MPI_INFO_NULL,
+                                xcomm->local_comm);
+        }
+        Communicator::cached_local_comms.insert(
+            {{xcomm->global_comm, ppn_override}, xcomm->local_comm});
     }
 
-    int local_rank;
-    MPI_Comm_rank(xcomm->local_comm, &local_rank);
+    if (Communicator::cached_group_comms.contains({xcomm->global_comm, ppn_override}))
+    {
+        xcomm->group_comm =
+            Communicator::cached_group_comms.at({xcomm->global_comm, ppn_override});
+    }
+    else
+    {
+        int local_rank;
+        MPI_Comm_rank(xcomm->local_comm, &local_rank);
 
-    // Split global comm into group (per local rank) communicators
-    MPI_Comm_split(xcomm->global_comm, local_rank, rank, &(xcomm->group_comm));
+        // Split global comm into group (per local rank) communicators
+        MPI_Comm_split(xcomm->global_comm, local_rank, rank, xcomm->group_comm);
+        Communicator::cached_group_comms.insert(
+            {{xcomm->global_comm, ppn_override}, xcomm->group_comm});
+    }
 
     return MPI_SUCCESS;
 }
@@ -161,6 +181,8 @@ int initialize_topo_communicator(MPIL_Comm* xcomm, int ppn_override = 0)
  * @return MPI_SUCCESS
  **/
 int initialize_rank_mapping(MPIL_Comm* xcomm);
+
+int free_rank_mapping(MPIL_Comm* xcomm);
 
 /** @brief Gets current tag from xcomm then increments MPIL_Comm::tag
         @details

--- a/library/include/communicator/global_comms.hpp
+++ b/library/include/communicator/global_comms.hpp
@@ -3,10 +3,72 @@
 
 #include <mpi.h>
 
+#include <iostream>
+#include <map>
+#include <memory>
+
 namespace Communicator
 {
     /**@brief Global MPI Communicator to replace MPI_COMM_WORLD inside this library */
     extern MPI_Comm WORLD_COMM;
+
+    class CachedComm
+    {
+      public:
+        explicit CachedComm(MPI_Comm comm) : my_comm(new MPI_Comm(comm), CommDeleter{}) {
+        }
+
+        operator MPI_Comm() const
+        {
+            return my_comm ? *my_comm : MPI_COMM_NULL;
+        }
+
+        operator MPI_Comm*() const
+        {
+            return my_comm.get();
+        }
+
+        void test()
+        {
+            std::cout << my_comm.use_count() << std::endl;
+        }
+
+      private:
+        struct CommDeleter
+        {
+            void operator()(MPI_Comm* comm) const
+            {
+                if (comm)
+                {
+                    if (*comm != MPI_COMM_WORLD && *comm != MPI_COMM_SELF &&
+                        *comm != MPI_COMM_NULL)
+                    {
+                        int finalized = 0;
+                        MPI_Finalized(&finalized);
+
+                        if (!finalized)
+                        {
+                            MPI_Comm_free(comm);
+                        }
+                        else
+                        {
+                            std::cerr << "[Warning] MPI already finalized. Cannot free "
+                                         "MPI_Comm safely."
+                                      << std::endl;
+                        }
+                    }
+                    delete comm;  // Delete the dynamically allocated MPI_Comm variable
+                                  // itself
+                }
+            }
+        };
+
+        std::shared_ptr<MPI_Comm> my_comm;
+    };
+
+    extern std::map<std::tuple<MPI_Comm, int>, CachedComm> cached_local_comms;
+    extern std::map<std::tuple<MPI_Comm, int>, CachedComm> cached_group_comms;
+
 }  // namespace Communicator
 
 #endif

--- a/library/include/communicator/global_comms.hpp
+++ b/library/include/communicator/global_comms.hpp
@@ -9,33 +9,65 @@
 
 namespace Communicator
 {
-    /**@brief Global MPI Communicator to replace MPI_COMM_WORLD inside this library */
+    /** @brief Global MPI Communicator to replace MPI_COMM_WORLD inside this library */
     extern MPI_Comm WORLD_COMM;
 
+    /** @brief A reference-counted wrapper around an MPI communicator
+     * @details This class uses a shared pointer around an MPI_Comm object, which is
+     * manually allocated when the main constructor is called. If any of copy/move
+     * constructors are used, the shared_ptr semantics kick in an allow for reference
+     * counted communicators.
+     *
+     * This class also provides helper casting operations so that users do not need to
+     * manually cast to "MPI_Comm" or even "MPI_Comm*" when using this class. Users are
+     * free to free the one passed to the constructor, but users should NOT free the
+     * communicator this class holds onto. This is taken care of by the custom deleter
+     * provided to the shared_ptr (see CommDeleter)
+     *
+     * Take care when using this struct inside another struct that is malloc'ed (see
+     * ::initialize_comm_object)
+     **/
     class CachedComm
     {
       public:
-        explicit CachedComm(MPI_Comm comm) : my_comm(new MPI_Comm(comm), CommDeleter{}) {
+        /** @brief Main constructor for a CachedComm.
+         * @details Allocates a new MPI_Comm on the heap for the internal shared_ptr. Uses
+         * explicit to require the user to manually specify one must be created.
+         **/
+        explicit CachedComm(const MPI_Comm comm)
+            : my_comm(new MPI_Comm(comm), CommDeleter{})
+        {
         }
 
+        /** @brief Function to automatically cast to MPI_Comm
+         * @return The MPI_Comm inside the shared_ptr. If the shared_ptr has somehow been
+         * cleared, MPI_COMM_NULL is returned.
+         **/
         operator MPI_Comm() const
         {
             return my_comm ? *my_comm : MPI_COMM_NULL;
         }
 
+        /** @brief Function to automatically cast to MPI_Comm*
+         * @return The address of the MPI_Comm object inside the shared_ptr.
+         **/
         operator MPI_Comm*() const
         {
             return my_comm.get();
         }
 
-        void test()
-        {
-            std::cout << my_comm.use_count() << std::endl;
-        }
-
       private:
+        /** @brief Helper class for managing the MPI_Comm objects inside CachedComm */
         struct CommDeleter
         {
+            /** @brief The deleter function to be called.
+             * @details If the pointer is valid, this function will delete it.
+             * If the value at the pointer does not point to MPI_COMM_WORLD,
+             * MPI_COMM_SELF, or MPI_COMM_NULL, then this function attempts to free it.
+             * Before doing so, it checks if MPI has been finalized, and if it has, it
+             * prints a warning and does not free. Otherwise, the MPI_Comm is passed to
+             * MPI_Comm_free.
+             **/
             void operator()(MPI_Comm* comm) const
             {
                 if (comm)
@@ -63,10 +95,13 @@ namespace Communicator
             }
         };
 
+        /** @brief The reference counted MPI_Comm object. */
         std::shared_ptr<MPI_Comm> my_comm;
     };
 
+    /** @brief Map of cached local (per-node) MPI communicators */
     extern std::map<std::tuple<MPI_Comm, int>, CachedComm> cached_local_comms;
+    /** @brief Map of cached group (rank per-node) MPI communicators */
     extern std::map<std::tuple<MPI_Comm, int>, CachedComm> cached_group_comms;
 
 }  // namespace Communicator

--- a/library/include/communicator/global_comms.hpp
+++ b/library/include/communicator/global_comms.hpp
@@ -4,8 +4,8 @@
 #include <mpi.h>
 
 #include <iostream>
-#include <map>
 #include <memory>
+#include <vector>
 
 namespace Communicator
 {
@@ -99,10 +99,20 @@ namespace Communicator
         std::shared_ptr<MPI_Comm> my_comm;
     };
 
-    /** @brief Map of cached local (per-node) MPI communicators */
-    extern std::map<std::tuple<MPI_Comm, int>, CachedComm> cached_local_comms;
-    /** @brief Map of cached group (rank per-node) MPI communicators */
-    extern std::map<std::tuple<MPI_Comm, int>, CachedComm> cached_group_comms;
+    /** @brief A helper type to emulate a map "key" inside a vector */
+    using KeyTypes = std::tuple<MPI_Group, int>;
+    /** @brief The type of the cached comms "map" to be stored inside a vector */
+    using MapPairType = std::pair<KeyTypes, CachedComm>;
+
+    /** @brief "Map" of cached local (per-node) MPI communicators */
+    extern std::vector<MapPairType> cached_local_comms;
+    /** @brief "Map" of cached group (rank per-node) MPI communicators */
+    extern std::vector<MapPairType> cached_group_comms;
+
+    /** @brief Destructor for the MPI Groups stores inside ::cached_local_comms and
+     * ::cached_group_comms.
+     **/
+    void clear_comm_caches();
 
 }  // namespace Communicator
 

--- a/library/source/communicator/global_comms.cpp
+++ b/library/source/communicator/global_comms.cpp
@@ -1,5 +1,20 @@
 #include "communicator/global_comms.hpp"
 
 MPI_Comm Communicator::WORLD_COMM = MPI_COMM_NULL;
-std::map<std::tuple<MPI_Comm, int>, Communicator::CachedComm> Communicator::cached_local_comms;
-std::map<std::tuple<MPI_Comm, int>, Communicator::CachedComm> Communicator::cached_group_comms;
+std::vector<Communicator::MapPairType> Communicator::cached_local_comms;
+std::vector<Communicator::MapPairType> Communicator::cached_group_comms;
+
+void Communicator::clear_comm_caches()
+{
+    for (MapPairType& mpt : cached_local_comms)
+    {
+        MPI_Group_free(&(std::get<0>(mpt.first)));
+    }
+    cached_local_comms.clear();
+
+    for (MapPairType& mpt : cached_group_comms)
+    {
+        MPI_Group_free(&(std::get<0>(mpt.first)));
+    }
+    cached_group_comms.clear();
+}

--- a/library/source/communicator/global_comms.cpp
+++ b/library/source/communicator/global_comms.cpp
@@ -1,3 +1,5 @@
 #include "communicator/global_comms.hpp"
 
 MPI_Comm Communicator::WORLD_COMM = MPI_COMM_NULL;
+std::map<std::tuple<MPI_Comm, int>, Communicator::CachedComm> Communicator::cached_local_comms;
+std::map<std::tuple<MPI_Comm, int>, Communicator::CachedComm> Communicator::cached_group_comms;

--- a/library/source/communicator/initializers.cpp
+++ b/library/source/communicator/initializers.cpp
@@ -7,6 +7,9 @@ int initialize_comm_object(MPIL_Comm** xcomm_ptr, MPI_Comm global_comm)
     MPIL_Comm* xcomm   = (MPIL_Comm*)malloc(sizeof(MPIL_Comm));
     xcomm->global_comm = global_comm;
 
+    /* Because these are a C++ object, and xcomm is created from malloc,
+    * we need to tell C++ where to do the new so the constructor is actually
+    * called to initialize the shared_ptrs. */
     new (&xcomm->local_comm) Communicator::CachedComm(MPI_COMM_NULL);
     new (&xcomm->group_comm) Communicator::CachedComm(MPI_COMM_NULL);
 

--- a/library/source/communicator/initializers.cpp
+++ b/library/source/communicator/initializers.cpp
@@ -7,8 +7,8 @@ int initialize_comm_object(MPIL_Comm** xcomm_ptr, MPI_Comm global_comm)
     MPIL_Comm* xcomm   = (MPIL_Comm*)malloc(sizeof(MPIL_Comm));
     xcomm->global_comm = global_comm;
 
-    xcomm->local_comm = MPI_COMM_NULL;
-    xcomm->group_comm = MPI_COMM_NULL;
+    new (&xcomm->local_comm) Communicator::CachedComm(MPI_COMM_NULL);
+    new (&xcomm->group_comm) Communicator::CachedComm(MPI_COMM_NULL);
 
     xcomm->leader_comm       = MPI_COMM_NULL;
     xcomm->leader_group_comm = MPI_COMM_NULL;
@@ -98,6 +98,20 @@ int initialize_rank_mapping(MPIL_Comm* xcomm)
     MPI_Comm_size(xcomm->local_comm, &(xcomm->ppn));
     xcomm->num_nodes = ((num_procs - 1) / xcomm->ppn) + 1;
     xcomm->rank_node = get_node(xcomm, rank);
+
+    return MPI_SUCCESS;
+}
+
+int free_rank_mapping(MPIL_Comm* xcomm)
+{
+    free(xcomm->global_rank_to_local);
+    xcomm->global_rank_to_local = NULL;
+
+    free(xcomm->global_rank_to_node);
+    xcomm->global_rank_to_node = NULL;
+
+    free(xcomm->ordered_global_ranks);
+    xcomm->ordered_global_ranks = NULL;
 
     return MPI_SUCCESS;
 }

--- a/library/tests/tests/par_binary_IO.hpp
+++ b/library/tests/tests/par_binary_IO.hpp
@@ -32,7 +32,7 @@ void endian_swap(T* objp)
 }
 
 template <typename U>
-int readParMatrix(const char* filename, ParMat<U>& A)
+void readParMatrix(const char* filename, ParMat<U>& A)
 {
     int rank, num_procs;
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
@@ -58,22 +58,25 @@ int readParMatrix(const char* filename, ParMat<U>& A)
     FILE* ifile = fopen(filename, "rb");
     if (ifile == NULL)
     {
-        printf("Error openning file\n");
-        return 1;
+        printf("Error opening file\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     if (fseek(ifile, 0, SEEK_SET))
     {
         printf("Error seeking beginning of file\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
 
     n_items_read = fread(&code, sizeof_int32, 1, ifile);
     if (n_items_read == EOF)
     {
         printf("EOF reading code\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     if (ferror(ifile))
     {
         printf("Error reading code\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     if (code != PETSC_MAT_CODE)
     {
@@ -85,28 +88,34 @@ int readParMatrix(const char* filename, ParMat<U>& A)
     if (n_items_read == EOF)
     {
         printf("EOF reading code\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     if (ferror(ifile))
     {
         printf("Error reading N\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     n_items_read = fread(&global_num_cols, sizeof_int32, 1, ifile);
     if (n_items_read == EOF)
     {
         printf("EOF reading code\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     if (ferror(ifile))
     {
         printf("Error reading M\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     n_items_read = fread(&global_nnz, sizeof_int32, 1, ifile);
     if (n_items_read == EOF)
     {
         printf("EOF reading code\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     if (ferror(ifile))
     {
         printf("Error reading nnz\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
 
     if (is_little_endian)
@@ -234,6 +243,7 @@ int readParMatrix(const char* filename, ParMat<U>& A)
     if (fseek(ifile, pos, SEEK_SET))
     {
         printf("Error seeking pos\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     for (int i = 0; i < A.local_rows; i++)
     {
@@ -241,10 +251,12 @@ int readParMatrix(const char* filename, ParMat<U>& A)
         if (n_items_read == EOF)
         {
             printf("EOF reading code\n");
+            MPI_Abort(MPI_COMM_WORLD, 1);
         }
         if (ferror(ifile))
         {
             printf("Error reading row_size\n");
+            MPI_Abort(MPI_COMM_WORLD, 1);
         }
         if (is_little_endian)
         {
@@ -264,6 +276,7 @@ int readParMatrix(const char* filename, ParMat<U>& A)
     if (fseek(ifile, pos, SEEK_SET))
     {
         printf("Error seeking pos\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     for (int i = 0; i < nnz; i++)
     {
@@ -271,10 +284,12 @@ int readParMatrix(const char* filename, ParMat<U>& A)
         if (n_items_read == EOF)
         {
             printf("EOF reading code\n");
+            MPI_Abort(MPI_COMM_WORLD, 1);
         }
         if (ferror(ifile))
         {
             printf("Error reading col idx\n");
+            MPI_Abort(MPI_COMM_WORLD, 1);
         }
         if (is_little_endian)
         {
@@ -287,6 +302,7 @@ int readParMatrix(const char* filename, ParMat<U>& A)
     if (fseek(ifile, pos, SEEK_SET))
     {
         printf("Error seeking pos\n");
+        MPI_Abort(MPI_COMM_WORLD, 1);
     }
     for (int i = 0; i < nnz; i++)
     {
@@ -294,10 +310,12 @@ int readParMatrix(const char* filename, ParMat<U>& A)
         if (n_items_read == EOF)
         {
             printf("EOF reading code\n");
+            MPI_Abort(MPI_COMM_WORLD, 1);
         }
         if (ferror(ifile))
         {
             printf("Error reading value\n");
+            MPI_Abort(MPI_COMM_WORLD, 1);
         }
         if (is_little_endian)
         {
@@ -369,8 +387,6 @@ int readParMatrix(const char* filename, ParMat<U>& A)
     }
 
     A.off_proc.n_cols = A.off_proc_num_cols;
-
-    return 0;
 }
 
 #endif


### PR DESCRIPTION
Inside `initialize_topo_communicator`, there are a couple of `MPI_Comm_splits` that we can cache to avoid re-creating communicators that end up being the same pattern. The caching mechanism uses a "map" where the key is an MPI_Group representing the original global communicator and the "ppn_override" used to create the topology (If PPN is the normal MPI_COMM_TYPE_SHARED, the ppn_override is 0). In the comparison, only MPI_INDENT is considered a match.

To do this, there I made a C++ class that is basically a referenced MPI_Comm. To use a C++ class inside and MPIL_Comm, some uncommon (but valid) C++ allocation/destruction techniques were used. 

All new code is documented

Other small changes:
- Bumped c++ version to 20
- Added some frees for a few arrays inside the MPIL_Comm object that weren't free
- Fixed a few of the warnings that popped up (plus formatting)
- Changed the helper method `readParMatrix` to call `MPI_Abort` instead of returning an error.